### PR TITLE
Drop All Values After The Tag When Parsing

### DIFF
--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/NumericVersionTest.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/NumericVersionTest.scala
@@ -1,19 +1,25 @@
 package io.isomarcte.sbt.version.scheme.enforcer.core
 
 import coursier.version._
-import io.isomarcte.sbt.version.scheme.enforcer.core.SafeEquals._
 import munit._
 
 final class NumericVersionTest extends FunSuite {
 
   test("Correctly removes tags") {
-    assert(
-      NumericVersion.fromCoursierVersion(Version("1.0.0-SNAPSHOT")) ===
-        Right(NumericVersion.unsafeFromVector(Vector(BigInt(1), BigInt(0), BigInt(0))))
+    assertEquals(
+      NumericVersion.fromCoursierVersion(Version("1.0.0-SNAPSHOT")),
+      Right(NumericVersion.unsafeFromVectorIsTag(Vector(BigInt(1), BigInt(0), BigInt(0)), true))
     )
   }
 
   test("Disallows negative versions") {
     assert(NumericVersion.fromVector(Vector(BigInt(-1), BigInt(0), BigInt(0))).isLeft)
+  }
+
+  test("Drop all values after the first tag") {
+    assertEquals(
+      NumericVersion.fromString("0.0.0.1-RC2"),
+      Right(NumericVersion.unsafeFromVectorIsTag(Vector(0, 0, 0, 1).map(value => BigInt(value)), true))
+    )
   }
 }

--- a/project/GAVs.scala
+++ b/project/GAVs.scala
@@ -34,7 +34,7 @@ object GAVs {
   lazy val betterMonadicForV: String = "0.3.1"
   lazy val coursierVersionsV: String = "0.3.0"
   lazy val kindProjectorV: String    = "0.11.3"
-  lazy val munitV: String            = "0.7.21"
+  lazy val munitV: String            = "0.7.22"
   lazy val organizeImportsV          = "0.4.4"
   lazy val sbtLibraryManagementCoreV = "1.4.3"
   lazy val sbtMimaPluginV: String    = "0.8.1"


### PR DESCRIPTION
Coursier Version parses "0.0.0.1-RC1" as `Vector(0, 0, 0, 1 RC, 1)`. We want to drop all the values after the tag, but also record if the version was tagged.

The git automatic previous version code was also changed to attempt to find the first _non-tagged_ (in the version sense) tag (in the git sense), and then fallback to the first tagged version. This is because when working with some version "0.0.0.2-RC2" users are likely interested comparing to "0.0.0.1" _not_ "0.0.0.2-RC1".