### PR TITLE
Properly Fallback To Using Tagged Versions

### DIFF
--- a/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/SbtVersionSchemeEnforcer.scala
+++ b/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/SbtVersionSchemeEnforcer.scala
@@ -71,13 +71,8 @@ private[plugin] object SbtVersionSchemeEnforcer {
     }
 
   def previousTagFromGit: Either[Throwable, Option[String]] =
-    Try(
-      sys
-        .process
-        .Process(gitCommandWithOutTags, None)
-        .lineStream
-        .headOption
-        .orElse(sys.process.Process(gitCommandWithTags, None).lineStream.headOption)
-        .map(normalizeVersion)
-    ).toEither
+    Try(sys.process.Process(gitCommandWithOutTags, None).lineStream.headOption)
+      .orElse(Try(sys.process.Process(gitCommandWithTags, None).lineStream.headOption))
+      .toEither
+      .map(_.map(normalizeVersion))
 }


### PR DESCRIPTION
Fix bug where if the attempt to lookup non-tagged parent git tags fails, then we properly fallback to using tagged versions.