### PR TITLE
Add versionSchemeEnforcerIntialVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ version, everything else can be derived.
 
 The previous version of your project will be detected from the current commits most recent git tag.
 
-You can then run either `mimaReportBinaryIssues` as normal or `versionSchemeCheck` (differences explained below).
+You can then run either `mimaReportBinaryIssues` as normal or `versionSchemeEnforcerCheck` (differences explained below).
 
 If you are using a multi-module build and you don't want to run this on your the root project, then add this to your root project only.
 
@@ -64,17 +64,18 @@ _Any_ setting can be manually set at the project level and it will be left alone
 Name | Type | Description
 ---- | ---- | -----------
 versionSchemeEnforcerPreviousVersion | `Option[String]` | Previous version to compare against the current version for calculating binary compatibility. If you are using `git` and you have a tag as an ancestor to the current commit, this will be automatically derived.
-versionSchemeEnforcerChangeType | `Option[Either[Throwable, VersionChangeType]]` | The type of binary change. It is used to configured MiMa settings. Normally this is derived from versionSchemeEnforcerPreviousVersion and should not normally be set directly. If it results in an error and versionSchemeCheck is run, that error is raised. If the previous version is empty then this will be empty too in which case mima settings will not be altered in any way.
+versionSchemeEnforcerChangeType | `Either[Throwable, VersionChangeType]` | The type of binary change. It is used to configured MiMa settings. Normally this is derived from versionSchemeEnforcerPreviousVersion and should not normally be set directly. If it results in an error and versionSchemeEnforcerCheck is run, that error is raised.
+versionSchemeEnforcerIntialVersion | `Option[String]` | The initial version which should have the versionScheme enforced. If this is set then verions <= to this version will have Mima configured to not validate any binary compatibility constraints. This is particularly useful when you are adding a new module to an exsiting project.
 
 ## Tasks ##
 
 Name | Type | Description
 ---- | ---- | -----------
-versionSchemeCheck | `Unit` | Verifies that the sbt-version-scheme-enforcer settings are valid and runs MiMa with the derived settings. If versionSchemeEnforcerPreviousVersion is empty then this task will not run any binary checks or fail. Note, by default if using git versionSchemeEnforcerPreviousVersion is automatically derived, so if you want this behavior you need to explicitly set this. This can be particularly useful when adding new modules to multi-module builds.
+versionSchemeEnforcerCheck | `Unit` | Verifies that the sbt-version-scheme-enforcer settings are valid and runs MiMa with the derived settings.
 
-### Differnces Between `versionSchemeCheck` And `mimaReportBinaryIssues` ###
+### Differnces Between `versionSchemeEnforcerCheck` And `mimaReportBinaryIssues` ###
 
-`versionSchemeCheck` and `mimaReportBinaryIssues` are very similar, and in fact _most_ of what `versionSchemeCheck` does is just run `mimaReportBinaryIssues`. The only significant difference is that `versionSchemeCheck` will raise an error if any of the settings required from validating the version scheme are missing or invalid. For example, if you don't set `versionScheme` or set it to an invalid value `versionSchemeCheck` will fail. On the other hand, **if any of the settings required for verifying the version scheme are invalid/missing _none_ of the mima settings are modified by this plugin.**
+`versionSchemeEnforcerCheck` and `mimaReportBinaryIssues` are very similar, and in fact _most_ of what `versionSchemeEnforcerCheck` does is just run `mimaReportBinaryIssues`. The only significant difference is that `versionSchemeEnforcerCheck` will raise an error if any of the settings required from validating the version scheme are missing or invalid. For example, if you don't set `versionScheme` or set it to an invalid value `versionSchemeEnforcerCheck` will fail. On the other hand, **if any of the settings required for verifying the version scheme are invalid/missing _none_ of the mima settings are modified by this plugin.**
 
 This means that you can still run `mimaReportBinaryIssues` and this plugin will stay out of your way.
 

--- a/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/SafeEquals.scala
+++ b/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/SafeEquals.scala
@@ -3,8 +3,9 @@ package io.isomarcte.sbt.version.scheme.enforcer.core
 /** Type safe equality check. Normally you'd use `cats.kernel.Eq`, but we
   * don't want to add that dependency in the plugin.
   */
-private[core] object SafeEquals {
+private[enforcer] object SafeEquals {
   implicit final class SafeEqualsOps[A](value: A) {
     def ===(other: A): Boolean = value.equals(other)
+    def =!=(other: A): Boolean = (value === other) === false
   }
 }

--- a/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/SchemedVersion.scala
+++ b/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/SchemedVersion.scala
@@ -1,0 +1,54 @@
+package io.isomarcte.sbt.version.scheme.enforcer.core
+
+import coursier.version._
+
+/** A wrapper type for [[coursier.version.Version]] which properly handles PVP
+  * ordering. As of io.get-coursier:versions_2.12:0.3.0 does not.
+  */
+sealed trait SchemedVersion extends Ordered[SchemedVersion] {
+  import SchemedVersion._
+
+  def scheme: VersionCompatibility
+  def version: Version
+
+  final override def compare(that: SchemedVersion): Int =
+    (this.scheme, that.scheme) match {
+      case (a, b) if isPVP(a) && isPVP(b) =>
+        // Special case PVP because Coursier Version pads differing length
+        // versions to the same length, but PVP explicitly says that versions
+        // must be in strict lexicographic order, which implies that 1.0.0
+        // < 1.0.0.0 _not_ equal.
+        this.version.repr.compareTo(that.version.repr)
+      case _ =>
+        this.version.compare(that.version)
+    }
+}
+
+object SchemedVersion {
+
+  final private[this] case class SchemedVersionImpl(
+    override val version: Version,
+    override val scheme: VersionCompatibility
+  ) extends SchemedVersion
+
+  def fromVersionAndScheme(version: Version, scheme: VersionCompatibility): SchemedVersion =
+    SchemedVersionImpl(version, scheme)
+
+  def fromVersionStringAndScheme(version: String, scheme: VersionCompatibility): SchemedVersion =
+    fromVersionAndScheme(Version(version), scheme)
+
+  /** Helper function because it is awkward to handle the fact that
+    * [[coursier.version.VersionCompatibility]] has two representations for
+    * PVP.
+    */
+  private def isPVP(value: VersionCompatibility): Boolean =
+    value match {
+      case VersionCompatibility.PackVer =>
+        true
+      case VersionCompatibility.Default =>
+        true
+      case _ =>
+        false
+    }
+
+}

--- a/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/Keys.scala
+++ b/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/Keys.scala
@@ -5,15 +5,23 @@ import sbt._
 
 trait Keys {
 
+  // Settings
+
   final val versionSchemeEnforcerPreviousVersion: SettingKey[Option[String]] = settingKey[Option[String]](
     "Previous version to compare against the current version for calculating binary compatibility"
   )
-  final val versionSchemeEnforcerChangeType: SettingKey[Option[Either[Throwable, VersionChangeType]]] =
-    settingKey[Option[Either[Throwable, VersionChangeType]]](
-      "The type of binary change. It is used to configured MiMa settings. Normally this is derived from versionSchemeEnforcerPreviousVersion and should not normally be set directly. If it results in an error and versionSchemeCheck is run, that error is raised. If the previous version is empty then this will be empty too in which case mima settings will not be altered in any way."
+  final val versionSchemeEnforcerChangeType: SettingKey[Either[Throwable, VersionChangeType]] =
+    settingKey[Either[Throwable, VersionChangeType]](
+      "The type of binary change. It is used to configured MiMa settings. Normally this is derived from versionSchemeEnforcerPreviousVersion and should not normally be set directly. If it results in an error and versionSchemeEnforcerCheck is run, that error is raised."
     )
-  final val versionSchemeCheck: TaskKey[Unit] = taskKey[Unit](
-    "Verifies that the sbt-version-scheme-enforcer settings are valid and runs MiMa with the derived settings. If versionSchemeEnforcerPreviousVersion is empty then this task will not run any binary checks or fail. Note, by default if using git versionSchemeEnforcerPreviousVersion is automatically derived, so if you want this behavior you need to explicitly set this. This can be particularly useful when adding new modules to multi-module builds."
+  final val versionSchemeEnforcerIntialVersion: SettingKey[Option[String]] = settingKey[Option[String]](
+    "The initial version which should have the versionScheme enforced. If this is set then verions <= to this version will have Mima configured to not validate any binary compatibility constraints. This is particularly useful when you are adding a new module to an exsiting project."
+  )
+
+  // Tasks
+
+  final val versionSchemeEnforcerCheck: TaskKey[Unit] = taskKey[Unit](
+    "Verifies that the sbt-version-scheme-enforcer settings are valid and runs MiMa with the derived settings."
   )
 }
 

--- a/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/SbtVersionSchemeEnforcer.scala
+++ b/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/SbtVersionSchemeEnforcer.scala
@@ -1,5 +1,6 @@
 package io.isomarcte.sbt.version.scheme.enforcer.plugin
 
+import _root_.io.isomarcte.sbt.version.scheme.enforcer.core.SafeEquals._
 import _root_.io.isomarcte.sbt.version.scheme.enforcer.core._
 import coursier.version._
 import scala.util.Try
@@ -9,18 +10,19 @@ private[plugin] object SbtVersionSchemeEnforcer {
     scheme: Option[String],
     previousVersion: Option[String],
     nextVersion: String
-  ): Option[Either[Throwable, VersionChangeType]] = {
+  ): Either[Throwable, VersionChangeType] = {
     type ETV = Either[Throwable, VersionChangeType]
-    previousVersion.map(previousVersion =>
-      for {
-        s <- schemeToVersionCompatibility(scheme)
-        p <- versionToNumericVersion(previousVersion)
-        n <- versionToNumericVersion(nextVersion)
-        result <- VersionChangeType
-          .fromPreviousAndNextNumericVersion(s)(p, n)
-          .fold(e => Left(new RuntimeException(e)): ETV, value => Right(value): ETV)
-      } yield result
-    )
+    previousVersion
+      .fold(Left(new RuntimeException("versionSchemeEnforcerPreviousVersion is unset")): ETV)(previousVersion =>
+        for {
+          s <- schemeToVersionCompatibility(scheme)
+          p <- versionToNumericVersion(previousVersion)
+          n <- versionToNumericVersion(nextVersion)
+          result <- VersionChangeType
+            .fromPreviousAndNextNumericVersion(s)(p, n)
+            .fold(e => Left(new RuntimeException(e)): ETV, value => Right(value): ETV)
+        } yield result
+      )
   }
 
   def schemeToVersionCompatibility(scheme: Option[String]): Either[Throwable, VersionCompatibility] =
@@ -69,4 +71,22 @@ private[plugin] object SbtVersionSchemeEnforcer {
       .orElse(Try(sys.process.Process(gitCommandWithTags, None).lineStream.headOption))
       .toEither
       .map(_.map(normalizeVersion))
+
+  /** Checks if we should run mima by inspecting the initial version value on
+    * which to enforce the given `versionScheme` and the current version.
+    *
+    * Tags, e.g. `-SNAPSHOT`, are removed from the current version. If they
+    * weren't then the calculation would be wrong in certain circumstances.
+    */
+  def shouldRunMima(initialVersion: Option[String], currentVersion: String, scheme: Option[String]): Boolean =
+    scheme
+      .flatMap(VersionCompatibility.apply _)
+      .fold(false)(scheme =>
+        initialVersion.fold(true)(initialVersion =>
+          SchemedVersion
+            .fromVersionStringAndScheme(initialVersion, scheme)
+            // Need to remove any tag, e.g. -SNAPSHOT or the comparison will be wonky.
+            .compareTo(SchemedVersion.fromVersionStringAndScheme(currentVersion.takeWhile(_ =!= '-'), scheme)) < 0
+        )
+      )
 }

--- a/plugin/src/sbt-test/early-semver/0major/build.sbt
+++ b/plugin/src/sbt-test/early-semver/0major/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.13.4",
   versionSchemeEnforcerPreviousVersion := Some("0.1.0"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      Some(Right(VersionChangeType.Major))
-    val actual: Option[Either[Throwable, VersionChangeType]] =
+    val expected: Either[Throwable, VersionChangeType] =
+      Right(VersionChangeType.Major)
+    val actual: Either[Throwable, VersionChangeType] =
       versionSchemeEnforcerChangeType.value
     if (actual == expected) {
       ()

--- a/plugin/src/sbt-test/early-semver/0minor/build.sbt
+++ b/plugin/src/sbt-test/early-semver/0minor/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.13.4",
   versionSchemeEnforcerPreviousVersion := Some("0.1.0"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      Some(Right(VersionChangeType.Minor))
-    val actual: Option[Either[Throwable, VersionChangeType]] =
+    val expected: Either[Throwable, VersionChangeType] =
+      Right(VersionChangeType.Minor)
+    val actual: Either[Throwable, VersionChangeType] =
       versionSchemeEnforcerChangeType.value
     if (actual == expected) {
       ()

--- a/plugin/src/sbt-test/early-semver/1major/build.sbt
+++ b/plugin/src/sbt-test/early-semver/1major/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.13.4",
   versionSchemeEnforcerPreviousVersion := Some("1.0.0"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      Some(Right(VersionChangeType.Major))
-    val actual: Option[Either[Throwable, VersionChangeType]] =
+    val expected: Either[Throwable, VersionChangeType] =
+      Right(VersionChangeType.Major)
+    val actual: Either[Throwable, VersionChangeType] =
       versionSchemeEnforcerChangeType.value
     if (actual == expected) {
       ()

--- a/plugin/src/sbt-test/early-semver/1minor/build.sbt
+++ b/plugin/src/sbt-test/early-semver/1minor/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.13.4",
   versionSchemeEnforcerPreviousVersion := Some("1.0.0"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      Some(Right(VersionChangeType.Minor))
-    val actual: Option[Either[Throwable, VersionChangeType]] =
+    val expected: Either[Throwable, VersionChangeType] =
+      Right(VersionChangeType.Minor)
+    val actual: Either[Throwable, VersionChangeType] =
       versionSchemeEnforcerChangeType.value
     if (actual == expected) {
       ()

--- a/plugin/src/sbt-test/early-semver/1patch/build.sbt
+++ b/plugin/src/sbt-test/early-semver/1patch/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.13.4",
   versionSchemeEnforcerPreviousVersion := Some("1.0.0"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      Some(Right(VersionChangeType.Patch))
-    val actual: Option[Either[Throwable, VersionChangeType]] =
+    val expected: Either[Throwable, VersionChangeType] =
+      Right(VersionChangeType.Patch)
+    val actual: Either[Throwable, VersionChangeType] =
       versionSchemeEnforcerChangeType.value
     if (actual == expected) {
       ()

--- a/plugin/src/sbt-test/pvp/major/build.sbt
+++ b/plugin/src/sbt-test/pvp/major/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.13.4",
   versionSchemeEnforcerPreviousVersion := Some("0.0.1"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      Some(Right(VersionChangeType.Major))
-    val actual: Option[Either[Throwable, VersionChangeType]] =
+    val expected: Either[Throwable, VersionChangeType] =
+      Right(VersionChangeType.Major)
+    val actual: Either[Throwable, VersionChangeType] =
       versionSchemeEnforcerChangeType.value
     if (actual == expected) {
       ()

--- a/plugin/src/sbt-test/pvp/minor/build.sbt
+++ b/plugin/src/sbt-test/pvp/minor/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.13.4",
   versionSchemeEnforcerPreviousVersion := Some("0.0.0.1"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      Some(Right(VersionChangeType.Minor))
-    val actual: Option[Either[Throwable, VersionChangeType]] =
+    val expected: Either[Throwable, VersionChangeType] =
+      Right(VersionChangeType.Minor)
+    val actual: Either[Throwable, VersionChangeType] =
       versionSchemeEnforcerChangeType.value
     if (actual == expected) {
       ()

--- a/plugin/src/sbt-test/pvp/no-previous-version/build.sbt
+++ b/plugin/src/sbt-test/pvp/no-previous-version/build.sbt
@@ -5,12 +5,12 @@ ThisBuild / versionScheme := Some("pvp")
 lazy val root = (project in file(".")).settings(
   version := "0.1.0.0-SNAPSHOT",
   scalaVersion := "2.13.4",
-  versionSchemeEnforcerPreviousVersion := None,
+  versionSchemeEnforcerIntialVersion := Some("0.1.0.0"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      None
-    val actual: Option[Either[Throwable, VersionChangeType]] =
-      versionSchemeEnforcerChangeType.value
+    val expected: Set[ModuleID] =
+      Set.empty
+    val actual: Set[ModuleID] =
+      mimaPreviousArtifacts.value
     if (actual == expected) {
       ()
     } else {

--- a/plugin/src/sbt-test/pvp/patch/build.sbt
+++ b/plugin/src/sbt-test/pvp/patch/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.13.4",
   versionSchemeEnforcerPreviousVersion := Some("0.0.0.1"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      Some(Right(VersionChangeType.Patch))
-    val actual: Option[Either[Throwable, VersionChangeType]] =
+    val expected: Either[Throwable, VersionChangeType] =
+      Right(VersionChangeType.Patch)
+    val actual: Either[Throwable, VersionChangeType] =
       versionSchemeEnforcerChangeType.value
     if (actual == expected) {
       ()

--- a/plugin/src/sbt-test/semver-spec/0major/build.sbt
+++ b/plugin/src/sbt-test/semver-spec/0major/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.13.4",
   versionSchemeEnforcerPreviousVersion := Some("0.0.1"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      Some(Right(VersionChangeType.Major))
-    val actual: Option[Either[Throwable, VersionChangeType]] =
+    val expected: Either[Throwable, VersionChangeType] =
+      Right(VersionChangeType.Major)
+    val actual: Either[Throwable, VersionChangeType] =
       versionSchemeEnforcerChangeType.value
     if (actual == expected) {
       ()

--- a/plugin/src/sbt-test/semver-spec/major/build.sbt
+++ b/plugin/src/sbt-test/semver-spec/major/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.13.4",
   versionSchemeEnforcerPreviousVersion := Some("1.0.0"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      Some(Right(VersionChangeType.Major))
-    val actual: Option[Either[Throwable, VersionChangeType]] =
+    val expected: Either[Throwable, VersionChangeType] =
+      Right(VersionChangeType.Major)
+    val actual: Either[Throwable, VersionChangeType] =
       versionSchemeEnforcerChangeType.value
     if (actual == expected) {
       ()

--- a/plugin/src/sbt-test/semver-spec/minor/build.sbt
+++ b/plugin/src/sbt-test/semver-spec/minor/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.13.4",
   versionSchemeEnforcerPreviousVersion := Some("1.0.0"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      Some(Right(VersionChangeType.Minor))
-    val actual: Option[Either[Throwable, VersionChangeType]] =
+    val expected: Either[Throwable, VersionChangeType] =
+      Right(VersionChangeType.Minor)
+    val actual: Either[Throwable, VersionChangeType] =
       versionSchemeEnforcerChangeType.value
     if (actual == expected) {
       ()

--- a/plugin/src/sbt-test/semver-spec/patch/build.sbt
+++ b/plugin/src/sbt-test/semver-spec/patch/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.13.4",
   versionSchemeEnforcerPreviousVersion := Some("1.0.0"),
   TaskKey[Unit]("check") := {
-    val expected: Option[Either[Throwable, VersionChangeType]] =
-      Some(Right(VersionChangeType.Patch))
-    val actual: Option[Either[Throwable, VersionChangeType]] =
+    val expected: Either[Throwable, VersionChangeType] =
+      Right(VersionChangeType.Patch)
+    val actual: Either[Throwable, VersionChangeType] =
       versionSchemeEnforcerChangeType.value
     if (actual == expected) {
       ()

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0.1-SNAPSHOT"
+version in ThisBuild := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
This allows for declaring an initial version on which to enforce the version scheme. It is particularly useful when adding new modules to existing builds.

This effectively reverses the changes added in 0.1.0.0 for `versionSchemeEnforcerChangeType` to be `Option[Either[Throwable, VersionChangeType]]` as that didn't sufficiently allow for expressing this situation