### PR TITLE
Add Support For Detecting Java Version With Suffix In Build

### DIFF
--- a/project/JREMajorVersion.scala
+++ b/project/JREMajorVersion.scala
@@ -16,7 +16,8 @@ object JREMajorVersion {
   val majorVersion: String =
     sys
       .props
-      .get("java.version").map(_.takeWhile(_ != '-')) // handles things like '17-ea'
+      .get("java.version")
+      .map(_.takeWhile(_ != '-')) // handles things like '17-ea'
       .fold(
         throw new RuntimeException(
           "Unable to determine JRE major version since java.version is unset, which should not be possible for standard JVMs."

--- a/project/JREMajorVersion.scala
+++ b/project/JREMajorVersion.scala
@@ -16,7 +16,7 @@ object JREMajorVersion {
   val majorVersion: String =
     sys
       .props
-      .get("java.version")
+      .get("java.version").map(_.takeWhile(_ != '-')) // handles things like '17-ea'
       .fold(
         throw new RuntimeException(
           "Unable to determine JRE major version since java.version is unset, which should not be possible for standard JVMs."


### PR DESCRIPTION
This can happen for things like "Early Adopter" versions, e.g. '17-ea'.

This commit only effects the build of this project, not the logic of the provided libraries and plugins.