### PR TITLE
Ensure That We Fallback To versionSchemeEnforcerInitialVersion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,21 +21,11 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
         scala: [2.12.13]
         java: [adopt@1.11, adopt@1.15, adopt@1.8]
-        include:
-          - java: adopt@1.11
-            os: windows-latest
-        exclude:
-          - os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Ignore line ending differences in git
-        if: contains(runner.os, 'windows')
-        shell: bash
-        run: git config --global core.autocrlf false
-
       - name: Checkout current branch (full)
         uses: actions/checkout@v2
         with:
@@ -58,30 +48,22 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - shell: bash
-        run: sbt ++${{ matrix.scala }} scalafmtSbtCheck scalafmtCheckAll versionSchemeEnforcerCheck
+      - run: sbt ++${{ matrix.scala }} scalafmtSbtCheck scalafmtCheckAll versionSchemeEnforcerCheck
 
-      - shell: bash
-        run: sbt 'scalafixAll --check'
+      - run: sbt 'scalafixAll --check'
 
-      - shell: bash
-        run: sbt ++${{ matrix.scala }} publishLocal
+      - run: sbt ++${{ matrix.scala }} publishLocal
 
-      - shell: bash
-        run: |
+      - run: |
           sbt scripted
           ./run-vcs-tests.sh
 
-      - shell: bash
-        run: sbt ++${{ matrix.scala }} doc
+      - run: sbt ++${{ matrix.scala }} doc
 
       - name: Check that workflows are up to date
-        shell: bash
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
       - name: Build project
-        shell: bash
         run: sbt ++${{ matrix.scala }} test
 
-      - shell: bash
-        run: 'sbt ++${{ matrix.scala }} test:doc'
+      - run: 'sbt ++${{ matrix.scala }} test:doc'

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ ThisBuild / testFrameworks += new TestFramework("munit.Framework")
 // GithubWorkflow
 
 ThisBuild / githubWorkflowPublishTargetBranches := Nil
-ThisBuild / githubWorkflowOSes := Set("macos-latest", "windows-latest", "ubuntu-latest").toList
+ThisBuild / githubWorkflowOSes := Set("macos-latest", "ubuntu-latest").toList
 ThisBuild / githubWorkflowJavaVersions := Set("adopt@1.11", "adopt@1.15", "adopt@1.8").toList
 ThisBuild / githubWorkflowBuildPreamble :=
   List(
@@ -55,17 +55,6 @@ ThisBuild / githubWorkflowBuildPreamble :=
     WorkflowStep.Sbt(List("doc"))
   )
 ThisBuild / githubWorkflowBuildPostamble := List(WorkflowStep.Sbt(List("test:doc")))
-ThisBuild / githubWorkflowBuildMatrixExclusions :=
-  List(
-    // For some reason the `githubWorkflowCheck` step gets stuck with this
-    // particular combination.
-    MatrixExclude(Map("os" -> "windows-latest"))
-  )
-ThisBuild / githubWorkflowBuildMatrixInclusions :=
-  List(
-    // Give windows a chance with the latest LTS JVM.
-    MatrixInclude(matching = Map("java" -> "adopt@1.11"), additions = Map("os" -> "windows-latest"))
-  )
 
 // Doc Settings //
 

--- a/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/SbtVersionSchemeEnforcer.scala
+++ b/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/SbtVersionSchemeEnforcer.scala
@@ -15,10 +15,12 @@ private[plugin] object SbtVersionSchemeEnforcer {
     */
   def versionChangeTypeFromSchemeAndPreviousVersion(
     scheme: Option[String],
+    initialVersion: Option[String],
     previousVersion: Option[String],
     nextVersion: String
   ): Either[Throwable, VersionChangeType] =
     previousVersion
+      .orElse(initialVersion)
       .fold(Right(Option.empty[NumericVersion]): Either[Throwable, Option[NumericVersion]])(value =>
         NumericVersion.fromStringT(value).map(value => Option(value))
       )
@@ -72,7 +74,7 @@ private[plugin] object SbtVersionSchemeEnforcer {
     * Tags, e.g. `-SNAPSHOT`, are removed from the current version. If they
     * weren't then the calculation would be wrong in certain circumstances.
     */
-  def shouldRunMima(initialVersion: Option[String], currentVersion: String, scheme: Option[String]): Boolean =
+  def isAfterInitial(initialVersion: Option[String], currentVersion: String, scheme: Option[String]): Boolean =
     scheme
       .flatMap(VersionCompatibility.apply _)
       .fold(false)(scheme =>


### PR DESCRIPTION
Update the `versionChangeTypeFromSchemeAndPreviousVersion` function to always take in the `versionSchemeEnforcerInitialVersion` value. This way there is no chance that a scoping issue between the `Global`/`ThisBuild`/project scopes causing that function to fail.