### PR TITLE
Add Ability To Control Which VCS Tags Are Considered

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ versionSchemeEnforcerPreviousVersion | `Option[String]` | Previous version to co
 versionSchemeEnforcerChangeType | `Either[Throwable, VersionChangeType]` | The type of binary change. It is used to configured MiMa settings. Normally this is derived from versionSchemeEnforcerPreviousVersion and should not normally be set directly. If it results in an error and versionSchemeEnforcerCheck is run, that error is raised.
 versionSchemeEnforcerInitialVersion | `Option[String]` | The initial version which should have the versionScheme enforced. If this is set then verions <= to this version will have Mima configured to not validate any binary compatibility constraints. This is particularly useful when you are adding a new module to an exsiting project.
 versionSchemeEnforcerPreviousTagFilter | `String => Boolean` | A filter used when determining the previous version from a VCS tag. The selected tag will be the most recent tag, reachable from the current commit, for which this filter returns true. A common use case for this is not considering pre-release in binary compatibility checks. For example, assuming your versionScheme is Semver or Early Semver, if you are releasing 1.1.0-M3, you may want to consider binary compatibility compared to the last 1.0.x release, and permit arbitrary binary changes between various milestone releases. By default, comparing two versions which have the same numeric base version will imply that no visible changes have been made to the binary API, e.g. comparing 1.1.0-M2 to 1.1.0-M3 will yield a binary change type of Patch (assuming Semver or Early Semver.)
+versionSchemeEnforcerTagDomain | `TagDomain` | The domain of VCS tags to consider when looking for previous releases to use in the binary compatibility check. For example, this can be TagDomain.All to consider all tags on the repository, or TagDomain.Reachable to only consider tags which are reachable (ancestors) of the current commit. The later case can be useful when you have multiple branches which should not be considered directly related for the purposes of binary compatibility. TagDomain.All is the default as of 2.1.1.0. The behavior prior to 2.1.1.0 was equivalent to TagDomain.Reachable.
 
 ### Deprecated ###
 Name | Type | Description
@@ -116,6 +117,18 @@ import _root_.io.isomarcte.sbt.version.scheme.enforcer.plugin.TagFilters
 ThisBuild / versionSchemeEnforcerPreviousTagFilter := TagFilters.noMilestoneFilter
 
 ```
+
+## TagDomain ##
+
+`versionSchemeEnforcerTagDomain` describes which VCS tags to consider when attempting to automatically calculate the previous version. The default value is `TagDomain.All`, the possible values are described here.
+
+Name        | Description
+----------- | -----------
+All         | Consider all tags on the repository, even if they are not ancestors of the current commit.
+Reachable   | Only consider tags which are reachable (ancestors) of the current commit.
+Unreachable | Only consider tags which are unreachable (not ancestors) of the current commit. I don't know why you'd use this.
+Contains    | Only consider tags which contain this commit. I don't know why you'd use this.
+NoContains  | Only consider tags which do not contain this commit. This is similar to All, but will never include any tags which are present on this commit. In typical usage of this plugin it is unlikely this circumstance will occur.
 
 ## Why Does This Plugin Exist ##
 

--- a/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/Keys.scala
+++ b/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/Keys.scala
@@ -33,6 +33,10 @@ trait Keys {
     "A filter used when determining the previous version from a VCS tag. The selected tag will be the most recent tag, reachable from the current commit, for which this filter returns true. A common use case for this is not considering pre-release in binary compatibility checks. For example, assuming your versionScheme is Semver or Early Semver, if you are releasing 1.1.0-M3, you may want to consider binary compatibility compared to the last 1.0.x release, and permit arbitrary binary changes between various milestone releases. By default, comparing two versions which have the same numeric base version will imply that no visible changes have been made to the binary API, e.g. comparing 1.1.0-M2 to 1.1.0-M3 will yield a binary change type of Patch (assuming Semver or Early Semver.)"
   )
 
+  final val versionSchemeEnforcerTagDomain: SettingKey[TagDomain] = settingKey[TagDomain](
+    "The domain of VCS tags to consider when looking for previous releases to use in the binary compatibility check. For example, this can be TagDomain.All to consider all tags on the repository, or TagDomain.Reachable to only consider tags which are reachable (ancestors) of the current commit. The later case can be useful when you have multiple branches which should not be considered directly related for the purposes of binary compatibility. TagDomain.All is the default as of 2.1.1.0. The behavior prior to 2.1.1.0 was equivalent to TagDomain.Reachable."
+  )
+
   // Tasks
 
   final val versionSchemeEnforcerCheck: TaskKey[Unit] = taskKey[Unit](

--- a/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/SbtVersionSchemeEnforcerPlugin.scala
+++ b/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/SbtVersionSchemeEnforcerPlugin.scala
@@ -20,7 +20,8 @@ object SbtVersionSchemeEnforcerPlugin extends AutoPlugin {
       (versionSchemeEnforcerIntialVersion := None: @nowarn("cat=deprecation")),
       versionSchemeEnforcerInitialVersion := None,
       versionSchemeEnforcerPreviousVersion := None,
-      versionSchemeEnforcerPreviousTagFilter := Function.const(true)
+      versionSchemeEnforcerPreviousTagFilter := Function.const(true),
+      versionSchemeEnforcerTagDomain := TagDomain.All
     )
 
   override def buildSettings: Seq[Def.Setting[_]] =
@@ -41,7 +42,10 @@ object SbtVersionSchemeEnforcerPlugin extends AutoPlugin {
               Function.const(currentValue),
               vcs =>
                 vcs
-                  .previousTagVersionsFiltered(versionSchemeEnforcerPreviousTagFilter.value)
+                  .tagVersionsFiltered(
+                    versionSchemeEnforcerPreviousTagFilter.value,
+                    versionSchemeEnforcerTagDomain.value
+                  )
                   .headOption
                   .fold(initialValue)(previousTag => Some(previousTag.versionString))
             )

--- a/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/TagDomain.scala
+++ b/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/TagDomain.scala
@@ -1,0 +1,37 @@
+package io.isomarcte.sbt.version.scheme.enforcer.plugin
+
+/** ADT for describing which tags to consider when calculating previous
+  * versions.
+  */
+sealed abstract class TagDomain extends Product with Serializable
+
+object TagDomain {
+
+  /** Consider all tags on the repository, even if they are not ancestors of the
+    * current commit.
+    */
+  case object All extends TagDomain
+
+  /** Only consider tags which are reachable (ancestors) of the current commit.
+    */
+  case object Reachable extends TagDomain
+
+  /** Only consider tags which are unreachable (not ancestors) of the current commit.
+    *
+    * I don't know why you'd use this.
+    */
+  case object Unreachable extends TagDomain
+
+  /** Only consider tags which contain this commit.
+    *
+    * I don't know why you'd use this.
+    */
+  case object Contains extends TagDomain
+
+  /** Only consider tags which do not contain this commit. This is similar to
+    * All, but will never include any tags which are present on this
+    * commit. In typical usage of this plugin it is unlikely this circumstance
+    * will occur.
+    */
+  case object NoContains extends TagDomain
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.0.3-SNAPSHOT"
+ThisBuild / version := "2.1.1.0-SNAPSHOT"


### PR DESCRIPTION
This commit adds a new ADT `TagDomain` and an associated configuration key `versionSchemeEnforcerTagDomain`. They are used to describe which tags should be considered when calculating previous version values. The default is `TagDomain.All`. This changes the semantics from 2.1.0.2 where the behavior was equivalent to `TagDomain.Reachable`.