### PR TITLE
Add EarlySemVerVersion Data Type

### DIFF
--- a/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/EarlySemVerVersion.scala
+++ b/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/EarlySemVerVersion.scala
@@ -1,0 +1,31 @@
+package io.isomarcte.sbt.version.scheme.enforcer.core
+
+/** A data type which represents an early-semver version value.
+  *
+  * This is effectively a newtype on [[SemVerVersion]]. The primary difference
+  * is that while SemVer states that if the major version is 0, then any
+  * change should be considered to be binary breaking, Early SemVer
+  * effectively follows PVP for versions < 1.0.0. That is, 0.0.1 -> 0.1.0 is a
+  * binary breaking change, 0.0.1 -> 0.0.2 may introduce new
+  * symbols. Structurally, it is identical to SemVer.
+  *
+  * @see [[https://scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html Early SemVer]]
+  */
+sealed abstract class EarlySemVerVersion extends Product with Serializable {
+
+  /** The underlying [[SemVerVersion]]. */
+  def value: SemVerVersion
+
+  // final //
+
+  final override def toString: String = s"EarlySemVerVersion(${value.canonicalString})"
+}
+
+object EarlySemVerVersion {
+  final private[this] case class EarlySemVerVersionImpl(override val value: SemVerVersion) extends EarlySemVerVersion
+
+  /** Create an [[EarlySemVerVersion]] from a [[SemVerVersion]]. */
+  def apply(value: SemVerVersion): EarlySemVerVersion = EarlySemVerVersionImpl(value)
+
+  implicit val orderingInstance: Ordering[EarlySemVerVersion] = Ordering.by(_.value)
+}

--- a/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/SemVerVersion.scala
+++ b/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/SemVerVersion.scala
@@ -101,7 +101,7 @@ sealed abstract class SemVerVersion extends Product with Serializable {
   final def asVersionSections: VersionSections =
     semVerPrecedenceVersion.asVersionSections.withMetadataSection(metadataSection)
 
-  final override def toString: String = s"SemVerPrecedenceVersion(${canonicalString})"
+  final override def toString: String = s"SemVerVersion(${canonicalString})"
 }
 
 object SemVerVersion {

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/EarlySemVerVersionLaws.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/EarlySemVerVersionLaws.scala
@@ -1,0 +1,11 @@
+package io.isomarcte.sbt.version.scheme.enforcer.core
+
+import cats.implicits._
+import cats.kernel.laws.discipline._
+import io.isomarcte.sbt.version.scheme.enforcer.core.OrphanInstances._
+import munit._
+
+final class EarlySemVerVersionLaws extends DisciplineSuite {
+  checkAll("EarlySemVerVersion.OrderLaws", OrderTests[EarlySemVerVersion].order)
+  checkAll("EarlySemVerVersion.HashLaws", HashTests[EarlySemVerVersion].hash)
+}

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/OrphanInstances.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/OrphanInstances.scala
@@ -151,6 +151,15 @@ private[enforcer] trait OrphanInstances {
 
   implicit final val catsInstancesForSemVerVersion: Hash[SemVerVersion] with Order[SemVerVersion] =
     catsHashAndOrderFromOrdering[SemVerVersion]
+
+  implicit final val arbEarlySemVerVersion: Arbitrary[EarlySemVerVersion] = Arbitrary(
+    Arbitrary.arbitrary[SemVerVersion].map(EarlySemVerVersion.apply _)
+  )
+
+  implicit final val cogenEarlySemVerVersion: Cogen[EarlySemVerVersion] = Cogen[SemVerVersion].contramap(_.value)
+
+  implicit final val catsInstancesForEarlySemVerVersion: Hash[EarlySemVerVersion] with Order[EarlySemVerVersion] =
+    catsHashAndOrderFromOrdering[EarlySemVerVersion]
 }
 
 object OrphanInstances extends OrphanInstances


### PR DESCRIPTION
This is effectively a newtype on SemVerVersion. It exists to give distinct instances of typeclasses for EarlySemVerVersion values.