### PR TITLE
Add VersionChangeTypeClass

### DIFF
--- a/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/EarlySemVerVersion.scala
+++ b/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/EarlySemVerVersion.scala
@@ -30,8 +30,7 @@ object EarlySemVerVersion {
   def apply(value: SemVerVersion): EarlySemVerVersion = EarlySemVerVersionImpl(value)
 
   /** Attempt to create a [[SemVerVersion]] from a [[java.lang.String]]. */
-  def fromString(value: String): Either[String, EarlySemVerVersion] =
-    SemVerVersion.fromString(value).map(apply)
+  def fromString(value: String): Either[String, EarlySemVerVersion] = SemVerVersion.fromString(value).map(apply)
 
   /** As [[#fromString]], but throws an exception if the value is invalid.
     *
@@ -54,10 +53,7 @@ object EarlySemVerVersion {
           )
         } else {
           // SemVer Rules
-          VersionChangeTypeClass[SemVerVersion].changeType(
-            x.value,
-            y.value
-          )
+          VersionChangeTypeClass[SemVerVersion].changeType(x.value, y.value)
         }
     }
 }

--- a/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/EarlySemVerVersion.scala
+++ b/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/EarlySemVerVersion.scala
@@ -1,5 +1,7 @@
 package io.isomarcte.sbt.version.scheme.enforcer.core
 
+import io.isomarcte.sbt.version.scheme.enforcer.core.SafeEquals._
+
 /** A data type which represents an early-semver version value.
   *
   * This is effectively a newtype on [[SemVerVersion]]. The primary difference
@@ -27,5 +29,35 @@ object EarlySemVerVersion {
   /** Create an [[EarlySemVerVersion]] from a [[SemVerVersion]]. */
   def apply(value: SemVerVersion): EarlySemVerVersion = EarlySemVerVersionImpl(value)
 
+  /** Attempt to create a [[SemVerVersion]] from a [[java.lang.String]]. */
+  def fromString(value: String): Either[String, EarlySemVerVersion] =
+    SemVerVersion.fromString(value).map(apply)
+
+  /** As [[#fromString]], but throws an exception if the value is invalid.
+    *
+    * It is ''strongly'' recommended that this only be used on the REPL and in
+    * tests.
+    */
+  def unsafeFromString(value: String): EarlySemVerVersion =
+    fromString(value).fold(e => throw new IllegalArgumentException(e), identity)
+
   implicit val orderingInstance: Ordering[EarlySemVerVersion] = Ordering.by(_.value)
+
+  implicit def versionChangeTypeClassInstance: VersionChangeTypeClass[EarlySemVerVersion] =
+    new VersionChangeTypeClass[EarlySemVerVersion] {
+      override def changeType(x: EarlySemVerVersion, y: EarlySemVerVersion): VersionChangeType =
+        if (x.value.major === 0 && y.value.major === 0) {
+          // PVP rules
+          VersionChangeTypeClass[PVPVersion].changeType(
+            PVPVersion.fromVersionSections(x.value.asVersionSections),
+            PVPVersion.fromVersionSections(y.value.asVersionSections)
+          )
+        } else {
+          // SemVer Rules
+          VersionChangeTypeClass[SemVerVersion].changeType(
+            x.value,
+            y.value
+          )
+        }
+    }
 }

--- a/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/PVPVersion.scala
+++ b/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/PVPVersion.scala
@@ -171,4 +171,18 @@ object PVPVersion {
     * account in the ordering when they are present.
     */
   implicit val orderingInstance: Ordering[PVPVersion] = Ordering.by(_.asVersionSections)
+
+  implicit def versionChangeTypeClassInstance: VersionChangeTypeClass[PVPVersion] =
+    new VersionChangeTypeClass[PVPVersion] {
+      override def changeType(x: PVPVersion, y: PVPVersion): VersionChangeType =
+        if (x.major === y.major) {
+          if (x.minor === y.minor) {
+            VersionChangeType.Patch
+          } else {
+            VersionChangeType.Minor
+          }
+        } else {
+          VersionChangeType.Major
+        }
+    }
 }

--- a/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/SemVerVersion.scala
+++ b/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/SemVerVersion.scala
@@ -1,5 +1,7 @@
 package io.isomarcte.sbt.version.scheme.enforcer.core
 
+import io.isomarcte.sbt.version.scheme.enforcer.core.SafeEquals._
+
 /** A data type which represents a SemVer version.
   *
   * @note This value is special in one regard. The SemVer specification states
@@ -202,4 +204,26 @@ object SemVerVersion {
     *       `a == b` or `a.hashCode == b.hashCode`.
     */
   val semVerPrecedenceOrdering: Ordering[SemVerVersion] = Ordering.by(_.semVerPrecedenceVersion)
+
+  implicit val versionChangeTypeClassInstance: VersionChangeTypeClass[SemVerVersion] =
+    new VersionChangeTypeClass[SemVerVersion] {
+      override def changeType(x: SemVerVersion, y: SemVerVersion): VersionChangeType =
+        if (x.major === BigInt(0) || y.major === BigInt(0)) {
+          if (x.asVersionSections.numericSection === y.asVersionSections.numericSection) {
+            VersionChangeType.Patch
+          } else {
+            VersionChangeType.Major
+          }
+        } else {
+          if (x.major === y.major) {
+            if (x.minor === y.minor) {
+              VersionChangeType.Patch
+            } else {
+              VersionChangeType.Minor
+            }
+          } else {
+            VersionChangeType.Major
+          }
+        }
+    }
 }

--- a/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/VersionChangeTypeClass.scala
+++ b/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/VersionChangeTypeClass.scala
@@ -1,0 +1,20 @@
+package io.isomarcte.sbt.version.scheme.enforcer.core
+
+/** A typeclass for types which represent a version and can communicate an API
+  * change. For example, SemVer, EarlySemVer, and PVP are all members of this
+  * typeclass because given two instances of any of those version types we can
+  * determine what the API change denoted by the versions is.
+  */
+trait VersionChangeTypeClass[A] extends Serializable {
+
+  /** Given two version types, determine the communicated API change between the two.
+    *
+    * @note The method is commutative, e.g. `changeType(x, y) == changeType(y,
+    *       x)` for all x and y.
+    */
+  def changeType(x: A, y: A): VersionChangeType
+}
+
+object VersionChangeTypeClass {
+  def apply[A](implicit A: VersionChangeTypeClass[A]): VersionChangeTypeClass[A] = A
+}

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/EarlySemVerTests.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/EarlySemVerTests.scala
@@ -1,0 +1,20 @@
+package io.isomarcte.sbt.version.scheme.enforcer.core
+
+import munit._
+
+final class EarlySemVerVersionTests extends FunSuite {
+  test("VersionChangeTypeClass") {
+    val instance: VersionChangeTypeClass[EarlySemVerVersion] = VersionChangeTypeClass[EarlySemVerVersion]
+
+    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("0.0.0"), EarlySemVerVersion.unsafeFromString("0.0.0")), VersionChangeType.Patch)
+    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("0.0.0"), EarlySemVerVersion.unsafeFromString("0.0.1")), VersionChangeType.Minor)
+    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("0.0.0"), EarlySemVerVersion.unsafeFromString("0.1.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("0.0.0"), EarlySemVerVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("0.1.0"), EarlySemVerVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
+
+    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("1.0.0"), EarlySemVerVersion.unsafeFromString("1.0.0")), VersionChangeType.Patch)
+    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("1.0.0"), EarlySemVerVersion.unsafeFromString("1.0.1")), VersionChangeType.Patch)
+    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("1.0.0"), EarlySemVerVersion.unsafeFromString("1.1.0")), VersionChangeType.Minor)
+    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("1.0.0"), EarlySemVerVersion.unsafeFromString("2.0.0")), VersionChangeType.Major)
+  }
+}

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/EarlySemVerTests.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/EarlySemVerTests.scala
@@ -6,15 +6,42 @@ final class EarlySemVerVersionTests extends FunSuite {
   test("VersionChangeTypeClass") {
     val instance: VersionChangeTypeClass[EarlySemVerVersion] = VersionChangeTypeClass[EarlySemVerVersion]
 
-    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("0.0.0"), EarlySemVerVersion.unsafeFromString("0.0.0")), VersionChangeType.Patch)
-    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("0.0.0"), EarlySemVerVersion.unsafeFromString("0.0.1")), VersionChangeType.Minor)
-    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("0.0.0"), EarlySemVerVersion.unsafeFromString("0.1.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("0.0.0"), EarlySemVerVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("0.1.0"), EarlySemVerVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
+    assertEquals(
+      instance.changeType(EarlySemVerVersion.unsafeFromString("0.0.0"), EarlySemVerVersion.unsafeFromString("0.0.0")),
+      VersionChangeType.Patch
+    )
+    assertEquals(
+      instance.changeType(EarlySemVerVersion.unsafeFromString("0.0.0"), EarlySemVerVersion.unsafeFromString("0.0.1")),
+      VersionChangeType.Minor
+    )
+    assertEquals(
+      instance.changeType(EarlySemVerVersion.unsafeFromString("0.0.0"), EarlySemVerVersion.unsafeFromString("0.1.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(EarlySemVerVersion.unsafeFromString("0.0.0"), EarlySemVerVersion.unsafeFromString("1.0.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(EarlySemVerVersion.unsafeFromString("0.1.0"), EarlySemVerVersion.unsafeFromString("1.0.0")),
+      VersionChangeType.Major
+    )
 
-    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("1.0.0"), EarlySemVerVersion.unsafeFromString("1.0.0")), VersionChangeType.Patch)
-    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("1.0.0"), EarlySemVerVersion.unsafeFromString("1.0.1")), VersionChangeType.Patch)
-    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("1.0.0"), EarlySemVerVersion.unsafeFromString("1.1.0")), VersionChangeType.Minor)
-    assertEquals(instance.changeType(EarlySemVerVersion.unsafeFromString("1.0.0"), EarlySemVerVersion.unsafeFromString("2.0.0")), VersionChangeType.Major)
+    assertEquals(
+      instance.changeType(EarlySemVerVersion.unsafeFromString("1.0.0"), EarlySemVerVersion.unsafeFromString("1.0.0")),
+      VersionChangeType.Patch
+    )
+    assertEquals(
+      instance.changeType(EarlySemVerVersion.unsafeFromString("1.0.0"), EarlySemVerVersion.unsafeFromString("1.0.1")),
+      VersionChangeType.Patch
+    )
+    assertEquals(
+      instance.changeType(EarlySemVerVersion.unsafeFromString("1.0.0"), EarlySemVerVersion.unsafeFromString("1.1.0")),
+      VersionChangeType.Minor
+    )
+    assertEquals(
+      instance.changeType(EarlySemVerVersion.unsafeFromString("1.0.0"), EarlySemVerVersion.unsafeFromString("2.0.0")),
+      VersionChangeType.Major
+    )
   }
 }

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/PVPVersionTests.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/PVPVersionTests.scala
@@ -35,4 +35,41 @@ final class PVPVersionTests extends FunSuite {
     assertEquals(version.preReleaseSection, Some(PreReleaseSection.unsafeFromString("-SNAPSHOT.1")))
     assertEquals(version.metadataSection, Some(MetadataSection.unsafeFromString("+0.1")))
   }
+
+  test("VersionChangeTypeClass") {
+    val instance: VersionChangeTypeClass[PVPVersion] = VersionChangeTypeClass[PVPVersion]
+
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.0.0")), VersionChangeType.Patch)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.0.1")), VersionChangeType.Minor)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.1.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.1.0"), PVPVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
+
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0"), PVPVersion.unsafeFromString("1.0.0")), VersionChangeType.Patch)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0"), PVPVersion.unsafeFromString("1.0.1")), VersionChangeType.Minor)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0"), PVPVersion.unsafeFromString("1.1.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0"), PVPVersion.unsafeFromString("2.0.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.1.0"), PVPVersion.unsafeFromString("2.0.0")), VersionChangeType.Major)
+
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.0.0")), VersionChangeType.Patch)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.0.1")), VersionChangeType.Minor)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.1.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.1.0"), PVPVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
+
+
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0.0"), PVPVersion.unsafeFromString("1.0.1")), VersionChangeType.Minor)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0.0"), PVPVersion.unsafeFromString("1.0.1.0")), VersionChangeType.Minor)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0.0"), PVPVersion.unsafeFromString("1.1.0.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0.0"), PVPVersion.unsafeFromString("2.0.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.1.0.0"), PVPVersion.unsafeFromString("2.0.0.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.1.0.0"), PVPVersion.unsafeFromString("1.1.0.0")), VersionChangeType.Patch)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.1.0.0"), PVPVersion.unsafeFromString("1.1.0.1")), VersionChangeType.Patch)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.1.0.0"), PVPVersion.unsafeFromString("1.1.0.1")), VersionChangeType.Patch)
+
+    // Unusual edge cases
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString(""), PVPVersion.unsafeFromString("1")), VersionChangeType.Major)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1"), PVPVersion.unsafeFromString("1.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0"), PVPVersion.unsafeFromString("1.0.0")), VersionChangeType.Minor)
+  }
 }

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/PVPVersionTests.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/PVPVersionTests.scala
@@ -39,37 +39,114 @@ final class PVPVersionTests extends FunSuite {
   test("VersionChangeTypeClass") {
     val instance: VersionChangeTypeClass[PVPVersion] = VersionChangeTypeClass[PVPVersion]
 
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.0.0")), VersionChangeType.Patch)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.0.1")), VersionChangeType.Minor)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.1.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.1.0"), PVPVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.0.0")),
+      VersionChangeType.Patch
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.0.1")),
+      VersionChangeType.Minor
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.1.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("1.0.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("0.1.0"), PVPVersion.unsafeFromString("1.0.0")),
+      VersionChangeType.Major
+    )
 
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0"), PVPVersion.unsafeFromString("1.0.0")), VersionChangeType.Patch)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0"), PVPVersion.unsafeFromString("1.0.1")), VersionChangeType.Minor)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0"), PVPVersion.unsafeFromString("1.1.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0"), PVPVersion.unsafeFromString("2.0.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.1.0"), PVPVersion.unsafeFromString("2.0.0")), VersionChangeType.Major)
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.0.0"), PVPVersion.unsafeFromString("1.0.0")),
+      VersionChangeType.Patch
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.0.0"), PVPVersion.unsafeFromString("1.0.1")),
+      VersionChangeType.Minor
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.0.0"), PVPVersion.unsafeFromString("1.1.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.0.0"), PVPVersion.unsafeFromString("2.0.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.1.0"), PVPVersion.unsafeFromString("2.0.0")),
+      VersionChangeType.Major
+    )
 
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.0.0")), VersionChangeType.Patch)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.0.1")), VersionChangeType.Minor)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.1.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("0.1.0"), PVPVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.0.0")),
+      VersionChangeType.Patch
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.0.1")),
+      VersionChangeType.Minor
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("0.1.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("0.0.0"), PVPVersion.unsafeFromString("1.0.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("0.1.0"), PVPVersion.unsafeFromString("1.0.0")),
+      VersionChangeType.Major
+    )
 
-
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0.0"), PVPVersion.unsafeFromString("1.0.1")), VersionChangeType.Minor)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0.0"), PVPVersion.unsafeFromString("1.0.1.0")), VersionChangeType.Minor)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0.0"), PVPVersion.unsafeFromString("1.1.0.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0.0.0"), PVPVersion.unsafeFromString("2.0.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.1.0.0"), PVPVersion.unsafeFromString("2.0.0.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.1.0.0"), PVPVersion.unsafeFromString("1.1.0.0")), VersionChangeType.Patch)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.1.0.0"), PVPVersion.unsafeFromString("1.1.0.1")), VersionChangeType.Patch)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.1.0.0"), PVPVersion.unsafeFromString("1.1.0.1")), VersionChangeType.Patch)
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.0.0.0"), PVPVersion.unsafeFromString("1.0.1")),
+      VersionChangeType.Minor
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.0.0.0"), PVPVersion.unsafeFromString("1.0.1.0")),
+      VersionChangeType.Minor
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.0.0.0"), PVPVersion.unsafeFromString("1.1.0.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.0.0.0"), PVPVersion.unsafeFromString("2.0.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.1.0.0"), PVPVersion.unsafeFromString("2.0.0.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.1.0.0"), PVPVersion.unsafeFromString("1.1.0.0")),
+      VersionChangeType.Patch
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.1.0.0"), PVPVersion.unsafeFromString("1.1.0.1")),
+      VersionChangeType.Patch
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.1.0.0"), PVPVersion.unsafeFromString("1.1.0.1")),
+      VersionChangeType.Patch
+    )
 
     // Unusual edge cases
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString(""), PVPVersion.unsafeFromString("1")), VersionChangeType.Major)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1"), PVPVersion.unsafeFromString("1.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(PVPVersion.unsafeFromString("1.0"), PVPVersion.unsafeFromString("1.0.0")), VersionChangeType.Minor)
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString(""), PVPVersion.unsafeFromString("1")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1"), PVPVersion.unsafeFromString("1.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(PVPVersion.unsafeFromString("1.0"), PVPVersion.unsafeFromString("1.0.0")),
+      VersionChangeType.Minor
+    )
   }
 }

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/SemVerVersionTests.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/SemVerVersionTests.scala
@@ -40,14 +40,38 @@ final class SemVerVersionTests extends FunSuite {
   test("VersionChangeTypeClass") {
     val instance: VersionChangeTypeClass[SemVerVersion] = VersionChangeTypeClass[SemVerVersion]
 
-    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("0.0.0"), SemVerVersion.unsafeFromString("0.0.0")), VersionChangeType.Patch)
-    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("0.0.0"), SemVerVersion.unsafeFromString("0.0.1")), VersionChangeType.Major)
-    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("0.0.0"), SemVerVersion.unsafeFromString("0.1.0")), VersionChangeType.Major)
-    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("0.0.0"), SemVerVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
+    assertEquals(
+      instance.changeType(SemVerVersion.unsafeFromString("0.0.0"), SemVerVersion.unsafeFromString("0.0.0")),
+      VersionChangeType.Patch
+    )
+    assertEquals(
+      instance.changeType(SemVerVersion.unsafeFromString("0.0.0"), SemVerVersion.unsafeFromString("0.0.1")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(SemVerVersion.unsafeFromString("0.0.0"), SemVerVersion.unsafeFromString("0.1.0")),
+      VersionChangeType.Major
+    )
+    assertEquals(
+      instance.changeType(SemVerVersion.unsafeFromString("0.0.0"), SemVerVersion.unsafeFromString("1.0.0")),
+      VersionChangeType.Major
+    )
 
-    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("1.0.0"), SemVerVersion.unsafeFromString("1.0.0")), VersionChangeType.Patch)
-    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("1.0.0"), SemVerVersion.unsafeFromString("1.0.1")), VersionChangeType.Patch)
-    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("1.0.0"), SemVerVersion.unsafeFromString("1.1.0")), VersionChangeType.Minor)
-    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("1.0.0"), SemVerVersion.unsafeFromString("2.0.0")), VersionChangeType.Major)
+    assertEquals(
+      instance.changeType(SemVerVersion.unsafeFromString("1.0.0"), SemVerVersion.unsafeFromString("1.0.0")),
+      VersionChangeType.Patch
+    )
+    assertEquals(
+      instance.changeType(SemVerVersion.unsafeFromString("1.0.0"), SemVerVersion.unsafeFromString("1.0.1")),
+      VersionChangeType.Patch
+    )
+    assertEquals(
+      instance.changeType(SemVerVersion.unsafeFromString("1.0.0"), SemVerVersion.unsafeFromString("1.1.0")),
+      VersionChangeType.Minor
+    )
+    assertEquals(
+      instance.changeType(SemVerVersion.unsafeFromString("1.0.0"), SemVerVersion.unsafeFromString("2.0.0")),
+      VersionChangeType.Major
+    )
   }
 }

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/SemVerVersionTests.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/SemVerVersionTests.scala
@@ -36,4 +36,18 @@ final class SemVerVersionTests extends FunSuite {
     )
     assert(SemVerVersion.unsafeFromString("1.0.0-RC+00000") < SemVerVersion.unsafeFromString("1.0.0-RC.1+0"))
   }
+
+  test("VersionChangeTypeClass") {
+    val instance: VersionChangeTypeClass[SemVerVersion] = VersionChangeTypeClass[SemVerVersion]
+
+    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("0.0.0"), SemVerVersion.unsafeFromString("0.0.0")), VersionChangeType.Patch)
+    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("0.0.0"), SemVerVersion.unsafeFromString("0.0.1")), VersionChangeType.Major)
+    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("0.0.0"), SemVerVersion.unsafeFromString("0.1.0")), VersionChangeType.Major)
+    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("0.0.0"), SemVerVersion.unsafeFromString("1.0.0")), VersionChangeType.Major)
+
+    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("1.0.0"), SemVerVersion.unsafeFromString("1.0.0")), VersionChangeType.Patch)
+    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("1.0.0"), SemVerVersion.unsafeFromString("1.0.1")), VersionChangeType.Patch)
+    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("1.0.0"), SemVerVersion.unsafeFromString("1.1.0")), VersionChangeType.Minor)
+    assertEquals(instance.changeType(SemVerVersion.unsafeFromString("1.0.0"), SemVerVersion.unsafeFromString("2.0.0")), VersionChangeType.Major)
+  }
 }


### PR DESCRIPTION
This is a typeclass for data types which represent a version which can be discriminated on to determine an intended API change.

It effectively replaces many of the methods in the `VersionChangeType` companion object. They will be deprecated in a future commit.