### PR TITLE
Add AlwaysVersion And StrictVersion Data Types

### DIFF
--- a/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/AlwaysVersion.scala
+++ b/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/AlwaysVersion.scala
@@ -1,0 +1,33 @@
+package io.isomarcte.sbt.version.scheme.enforcer.core
+
+/** A data type which represents a version scheme for which the visible API
+  * must be the same for all versions.
+  *
+  * I'm not sure how useful this is in practice. This data type exists because
+  * coursier and SBT support it.
+  *
+  * "Always" as in "Always compatible".
+  *
+  * @note There are not structural rules for this version. It may be an
+  *       arbitrary [[java.lang.String]].
+  */
+sealed abstract class AlwaysVersion extends Product with Serializable {
+  def value: String
+
+  // final //
+
+  override def toString: String = s"AlwaysVersion(${value})"
+}
+
+object AlwaysVersion {
+  final private[this] case class AlwaysVersionImpl(override val value: String) extends AlwaysVersion
+
+  def apply(value: String): AlwaysVersion = AlwaysVersionImpl(value)
+
+  implicit val orderingInstance: Ordering[AlwaysVersion] = Ordering.by(_.value)
+
+  implicit val versionChangeTypeClassInstance: VersionChangeTypeClass[AlwaysVersion] =
+    new VersionChangeTypeClass[AlwaysVersion] {
+      override def changeType(x: AlwaysVersion, y: AlwaysVersion): VersionChangeType = VersionChangeType.Patch
+    }
+}

--- a/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/StrictVersion.scala
+++ b/core/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/core/StrictVersion.scala
@@ -1,0 +1,38 @@
+package io.isomarcte.sbt.version.scheme.enforcer.core
+
+import io.isomarcte.sbt.version.scheme.enforcer.core.SafeEquals._
+
+/** A data type which represents a version scheme for which the visible API
+  * can change any time the version string changes.
+  *
+  * I'm not sure how useful this is in practice. This data type exists because
+  * coursier and SBT support it.
+  *
+  * @note There are not structural rules for this version. It may be an
+  *       arbitrary [[java.lang.String]].
+  */
+sealed abstract class StrictVersion extends Product with Serializable {
+  def value: String
+
+  // final //
+
+  override def toString: String = s"StrictVersion(${value})"
+}
+
+object StrictVersion {
+  final private[this] case class StrictVersionImpl(override val value: String) extends StrictVersion
+
+  def apply(value: String): StrictVersion = StrictVersionImpl(value)
+
+  implicit val orderingInstance: Ordering[StrictVersion] = Ordering.by(_.value)
+
+  implicit val versionChangeTypeClassInstance: VersionChangeTypeClass[StrictVersion] =
+    new VersionChangeTypeClass[StrictVersion] {
+      override def changeType(x: StrictVersion, y: StrictVersion): VersionChangeType =
+        if (x.value === y.value) {
+          VersionChangeType.Patch
+        } else {
+          VersionChangeType.Major
+        }
+    }
+}

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/AlwaysVersionLaws.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/AlwaysVersionLaws.scala
@@ -1,0 +1,11 @@
+package io.isomarcte.sbt.version.scheme.enforcer.core
+
+import cats.implicits._
+import cats.kernel.laws.discipline._
+import io.isomarcte.sbt.version.scheme.enforcer.core.OrphanInstances._
+import munit._
+
+final class AlwaysVersionLaws extends DisciplineSuite {
+  checkAll("AlwaysVersion.OrderLaws", OrderTests[AlwaysVersion].order)
+  checkAll("AlwaysVersion.HashLaws", HashTests[AlwaysVersion].hash)
+}

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/AlwaysVersionProperties.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/AlwaysVersionProperties.scala
@@ -1,0 +1,12 @@
+package io.isomarcte.sbt.version.scheme.enforcer.core
+
+import io.isomarcte.sbt.version.scheme.enforcer.core.OrphanInstances._
+import org.scalacheck.Prop._
+import org.scalacheck._
+
+final class AlwaysVersionProperties extends Properties("AlwaysVersion Properties") {
+
+  property("VersionChangeTypeClass") = forAll((x: AlwaysVersion, y: AlwaysVersion) =>
+    VersionChangeTypeClass[AlwaysVersion].changeType(x, y) ?= VersionChangeType.Patch
+  )
+}

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/OrphanInstances.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/OrphanInstances.scala
@@ -169,6 +169,24 @@ private[enforcer] trait OrphanInstances {
 
   implicit final val catsInstancesForPVPVersion: Hash[PVPVersion] with Order[PVPVersion] =
     catsHashAndOrderFromOrdering[PVPVersion]
+
+  implicit final val arbAlwaysVersion: Arbitrary[AlwaysVersion] = Arbitrary(
+    Arbitrary.arbitrary[String].map(AlwaysVersion.apply)
+  )
+
+  implicit final val cogenAlwaysVersion: Cogen[AlwaysVersion] = Cogen[String].contramap(_.value)
+
+  implicit final val catsInstancesForAlwaysVersion: Hash[AlwaysVersion] with Order[AlwaysVersion] =
+    catsHashAndOrderFromOrdering[AlwaysVersion]
+
+  implicit final val arbStrictVersion: Arbitrary[StrictVersion] = Arbitrary(
+    Arbitrary.arbitrary[String].map(StrictVersion.apply)
+  )
+
+  implicit final val cogenStrictVersion: Cogen[StrictVersion] = Cogen[String].contramap(_.value)
+
+  implicit final val catsInstancesForStrictVersion: Hash[StrictVersion] with Order[StrictVersion] =
+    catsHashAndOrderFromOrdering[StrictVersion]
 }
 
 object OrphanInstances extends OrphanInstances

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/StrictVersionLaws.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/StrictVersionLaws.scala
@@ -1,0 +1,11 @@
+package io.isomarcte.sbt.version.scheme.enforcer.core
+
+import cats.implicits._
+import cats.kernel.laws.discipline._
+import io.isomarcte.sbt.version.scheme.enforcer.core.OrphanInstances._
+import munit._
+
+final class StrictVersionLaws extends DisciplineSuite {
+  checkAll("StrictVersion.OrderLaws", OrderTests[StrictVersion].order)
+  checkAll("StrictVersion.HashLaws", HashTests[StrictVersion].hash)
+}

--- a/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/StrictVersionProperties.scala
+++ b/core/src/test/scala/io/isomarcte/sbt/version/scheme/enforcer/core/StrictVersionProperties.scala
@@ -1,0 +1,17 @@
+package io.isomarcte.sbt.version.scheme.enforcer.core
+
+import io.isomarcte.sbt.version.scheme.enforcer.core.OrphanInstances._
+import io.isomarcte.sbt.version.scheme.enforcer.core.SafeEquals._
+import org.scalacheck.Prop._
+import org.scalacheck._
+
+final class StrictVersionProperties extends Properties("StrictVersion Properties") {
+
+  property("VersionChangeTypeClass") = forAll((x: StrictVersion, y: StrictVersion) =>
+    if (x === y) {
+      VersionChangeTypeClass[StrictVersion].changeType(x, y) ?= VersionChangeType.Patch
+    } else {
+      VersionChangeTypeClass[StrictVersion].changeType(x, y) ?= VersionChangeType.Major
+    }
+  )
+}


### PR DESCRIPTION
With the addition of these data types, we can now model all schemes supported by SBT