### PR TITLE
Correct `gitTagStrings` 

### DIFF
--- a/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/vcs/Git.scala
+++ b/plugin/src/main/scala/io/isomarcte/sbt/version/scheme/enforcer/plugin/vcs/Git.scala
@@ -43,7 +43,8 @@ private[plugin] object Git {
             "--no-pager",
             "tag",
             "--format=%(refname:strip=2) %(creatordate:iso-strict)",
-            "--sort=-creatordate"
+            "--sort=-creatordate",
+            "--merged",
           ) ++ domainToArgSeq(domain)
         )
         .lineStream(VCS.silentProcessLogger)


### PR DESCRIPTION
Scala says 'previous tags reachable from this commit' but it was actually doing all tags, adding `--merged` filters to just the current `HEAD` and parents.